### PR TITLE
Remove hard-coded image path for development and CI deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,11 @@ manifests-cleanup:
 	rm -rf _out
 
 manifests: operator-courier csv-generator manifests-cleanup manifests-prepare operator-sdk
-	./hack/make-manifests.sh ${IMAGE_TAG}
+	./hack/make-manifests.sh ${IMAGE_REGISTRY}/${OPERATOR_IMAGE}:${IMAGE_TAG}
 	./hack/release-manifests.sh ${IMAGE_TAG}
+
+deploy: manifests
+	./hack/deploy-operator.sh
 
 release: manifests container-build container-release
 

--- a/hack/deploy-operator.sh
+++ b/hack/deploy-operator.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+oc apply -f _out/kubevirt-ssp-operator-crd.yaml
+oc apply -f _out/kubevirt-ssp-operator-cr.yaml
+oc apply -f _out/kubevirt-ssp-operator.yaml

--- a/hack/make-manifests.sh
+++ b/hack/make-manifests.sh
@@ -6,13 +6,19 @@ SELF=$( realpath $0 )
 BASEPATH=$( dirname $SELF )
 
 # intentionally "impossible"/obviously wrong version
-TAG="${1:-v0.0.0}"
+IMAGE_PATH=$1
+
+if [ -z "$IMAGE_PATH" ]; then
+  echo "Expecting image path as \$1"
+  exit 1
+fi
+
+TAG="${IMAGE_PATH#*:}"
 VERSION=${TAG#v}  # prune initial 'v', which should be present
 CHANNEL="beta"
 CLUSTER_VERSIONED_DIR="cluster/${VERSION}"
 MANIFESTS_DIR="manifests/kubevirt-ssp-operator"
 MANIFESTS_VERSIONED_DIR="${MANIFESTS_DIR}/${TAG}"
-IMAGE_PATH="quay.io/fromani/kubevirt-ssp-operator-container:${TAG}"
 
 HAVE_COURIER=0
 if which operator-courier &> /dev/null; then


### PR DESCRIPTION
Added makefile target to allow for easier deployment during development and CI deployments.
This would help when deploying on OCP CI, as the image should be pulled from the OCP CI registry.

The steps to deploy should now be:
```
$ export IMAGE_REGISTRY=quay.io/oyahud IMAGE_TAG=devel
$ make container-build-operator
$ make container-push-operator
$ make manifests
$ make deploy
```
**Release note**:
```release-note
Image path is no longer hard-coded in deployments scripts
```

Signed-off-by: Omer Yahud <oyahud@redhat.com>