### PR TITLE
[Bugfix] Removed traces of ClaimOwnership role

### DIFF
--- a/roles/KubevirtMetricsAggregation/tasks/main.yml
+++ b/roles/KubevirtMetricsAggregation/tasks/main.yml
@@ -20,12 +20,11 @@
   register: promrules
 
 - name: Inject owner references for KubevirtMetricsAggregation
-  include_role:
-    name: ClaimOwnership
-  vars:
-    object: "{{ item.result }}"
-    owner: "{{ cr_info }}"
-  with_items: "{{ promrules.results }}"
+  k8s:
+    state: present
+    namespace: "{{ cr_info.metadata.namespace }}"
+    merge_type: ['merge', 'json']
+    definition: "{{ [promrules.results[0].result] | k8s_inject_ownership(cr_info) }}"
 
 - name: Set available condition
   operator_sdk.util.k8s_status:

--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -24,16 +24,19 @@
   register: tv
 
 # Actively inject owner references in order to adopt existing resources during an upgrade
+- name: Collect owned objects
+  set_fact:
+    objects:
+      - "{{ tv.results[0].result }}" # ServiceAccount
+      - "{{ tv.results[2].result }}" # Service
+      - "{{ tv.results[3].result }}" # Deployment
+
 - name: Inject owner references for KubevirtTemplateValidator
-  include_role:
-    name: ClaimOwnership
-  vars:
-    object: "{{ item }}"
-    owner: "{{ cr_info }}"
-  with_list:
-  - "{{ tv.results[0].result }}" # ServiceAccount
-  - "{{ tv.results[2].result }}" # Service
-  - "{{ tv.results[3].result }}" # Deployment
+  k8s:
+    state: present
+    namespace: "{{ cr_info.metadata.namespace }}"
+    merge_type: ['merge', 'json']
+    resource_definition: "{{ objects | k8s_inject_ownership(cr_info) }}"
 
 - name: Register the webhook
   k8s:


### PR DESCRIPTION
Removed traces of ClaimOwnership role which was replaced with a python module
https://github.com/kubevirt/kubevirt-ssp-operator/pull/202

Signed-off-by: Omer Yahud <oyahud@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This fixes a bug that prevents template validator and metrics aggregator from reporting proper conditions because their playbooks were using a role that was removed from the operator.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
