### PR TITLE
Removed operand versions from CRs

### DIFF
--- a/deploy/crds/kubevirt_v1_commontemplatesbundle_cr.yaml
+++ b/deploy/crds/kubevirt_v1_commontemplatesbundle_cr.yaml
@@ -2,5 +2,3 @@ apiVersion: ssp.kubevirt.io/v1
 kind: KubevirtCommonTemplatesBundle
 metadata:
   name: kubevirt-common-template-bundle
-spec:
-  version: v0.7.0

--- a/deploy/crds/kubevirt_v1_metricsaggregation_cr.yaml
+++ b/deploy/crds/kubevirt_v1_metricsaggregation_cr.yaml
@@ -2,5 +2,3 @@ apiVersion: ssp.kubevirt.io/v1
 kind: KubevirtMetricsAggregation
 metadata:
   name: kubevirt-metrics-aggregation
-spec:
-  version: v0.0.1

--- a/deploy/crds/kubevirt_v1_nodelabellerbundle_cr.yaml
+++ b/deploy/crds/kubevirt_v1_nodelabellerbundle_cr.yaml
@@ -2,5 +2,4 @@ apiVersion: ssp.kubevirt.io/v1
 kind: KubevirtNodeLabellerBundle
 metadata:
   name: kubevirt-node-labeller-bundle
-spec:
-  version: v0.1.1
+

--- a/deploy/crds/kubevirt_v1_templatevalidator_cr.yaml
+++ b/deploy/crds/kubevirt_v1_templatevalidator_cr.yaml
@@ -4,5 +4,4 @@ metadata:
   name: kubevirt-template-validator
   namespace: kubevirt
 spec:
-  version: v0.6.6
   templateValidatorReplicas: 2


### PR DESCRIPTION
Signed-off-by: Omer Yahud <oyahud@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Removes the operand version from our CRs so that the configured version in `_defaults.yaml` is not overriden.
There is not much sense in deploying anything but latest releases of our operands as we ship the operator and it's operands as a complete product.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This fixes issues with local/testing deployments when old versions of operands might be deployed if the developer missed the fact that the CRs were versioned.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
