### PR TITLE
[OCP CI] Deploying the operator image on OCP CI using tags instead of digest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,8 @@ functests: manifests
 # IMAGE_FORMAT environment variable contains the container registry of the build image 
 # like so: 'registry.svc.ci.openshift.org/ci-op-qr0i5qnz/stable:' then the tag of that
 # image should be the image name of our operator.
-ocp-ci-manifests: operator-courier csv-generator manifests-cleanup manifests-prepare operator-sdk
-	component=$(OPERATOR_IMAGE) ./hack/make-manifests.sh $(IMAGE_FORMAT)$(OPERATOR_IMAGE)
-	./hack/release-manifests.sh $(OPERATOR_IMAGE)
+ocp-ci-manifests: manifests-cleanup manifests-prepare
+	component=$(OPERATOR_IMAGE) ./hack/make-ocp-ci-manifests.sh $(IMAGE_FORMAT)$(OPERATOR_IMAGE)
 
 ocp-ci-deploy: ocp-ci-manifests
 	./hack/deploy-operator.sh

--- a/hack/make-ocp-ci-manifests.sh
+++ b/hack/make-ocp-ci-manifests.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -ex
+
+SELF=$( realpath $0 )
+BASEPATH=$( dirname $SELF )
+
+# intentionally "impossible"/obviously wrong version
+IMAGE_PATH=$1
+
+if [ -z "$IMAGE_PATH" ]; then
+  echo "Expecting image path as \$1"
+  exit 1
+fi
+
+echo $IMAGE_PATH
+
+TAG="${IMAGE_PATH#*:}"
+
+(
+for CRD in $( ls deploy/crds/*crd.yaml ); do
+	echo "---"
+	cat ${CRD}
+done
+) > _out/kubevirt-ssp-operator-crd.yaml
+
+(
+for CR in $( ls deploy/crds/*cr.yaml ); do
+	echo "---"
+	cat ${CR}
+done
+) > _out/kubevirt-ssp-operator-cr.yaml
+
+(
+for MF in deploy/service_account.yaml deploy/role.yaml deploy/role_binding.yaml deploy/operator.yaml; do
+	echo "---"
+	sed "s|REPLACE_IMAGE|${IMAGE_PATH}|g ; s|REPLACE_VERSION|${TAG}|g" < ${MF}
+done
+) > _out/kubevirt-ssp-operator.yaml


### PR DESCRIPTION
Deploying the operator image on OCP CI using tags instead of digest because the test container in OCP ci does not support docker-in-docker so cannot fetch the image digest before deploying

Signed-off-by: Omer Yahud <oyahud@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes OCP CI deployment

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
