### PR TITLE
Removed the manifests generation from functests make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ deploy: manifests
 
 release: manifests container-build container-release
 
-functests: manifests
+functests:
 	cd functests && ./test-runner.sh
 
 # OCP CI specific targets


### PR DESCRIPTION
Removed the manifests generation when running functests to prevent repeated work (manifests are generated when running `make deploy`)

Signed-off-by: Omer Yahud <oyahud@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
