### PR TITLE
Added placement API to TemplateValidator

### DIFF
--- a/functests/05-test(enable-when-ocp-ci-ready)-deploy-template-validator.sh
+++ b/functests/05-test(enable-when-ocp-ci-ready)-deploy-template-validator.sh
@@ -10,7 +10,7 @@ TEST_NS="${KV_NAMESPACE}"
 
 oc create -n ${TEST_NS} -f "${SCRIPTPATH}/template-validator-unversioned-cr.yaml" || exit 2
 # TODO: SSP-operator needs to improve its feedback mechanism
-wait_template_validator_running ${TEST_NS} 5 600
+wait_template_validator_running ${TEST_NS} 5 60
 
 if is_template_validator_running ${TEST_NS}; then
 	RET=0

--- a/functests/10-template-validator-unversioned-cr.yaml
+++ b/functests/10-template-validator-unversioned-cr.yaml
@@ -1,0 +1,21 @@
+apiVersion: ssp.kubevirt.io/v1
+kind: KubevirtTemplateValidator
+metadata:
+  name: kubevirt-template-validator
+spec:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - preference:
+            matchExpressions:
+              - key: testKey
+                operator: In
+                values:
+                  - testValue
+          weight: 1
+  nodeSelector:
+    testKey: testValue
+  tolerations:
+  - effect: NoSchedule
+    key: testKey
+    operator: Exists

--- a/functests/10-test-template-validator-placement.sh
+++ b/functests/10-test-template-validator-placement.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+SCRIPTPATH=$( dirname $(readlink -f $0) )
+source ${SCRIPTPATH}/testlib.sh
+
+RET=0
+TEST_NS="${KV_NAMESPACE}"
+
+oc create -n ${TEST_NS} -f "${SCRIPTPATH}/10-template-validator-unversioned-cr.yaml" || exit 2
+
+# Wait for the operator to create the deployment, we don't care if pods are actually ready, as
+# we only check for the pod scheduling fields
+DEPLOYMENT_FOUND=false
+for i in {1..20}; do
+  oc get -n ${TEST_NS} deploy virt-template-validator
+  EXIT_CODE=$?
+  if (( $EXIT_CODE == 0 )); then
+    DEPLOYMENT_FOUND=true
+    break
+  else
+    sleep 10
+  fi
+done
+
+if [ "$DEPLOYMENT_FOUND" == "false" ]; then
+  echo "virt-template-validator deployment was not found"
+  exit 1
+fi
+
+NODE_SELECTOR=$(oc get -n ${TEST_NS} deploy virt-template-validator -ojson | jq '.spec.template.spec.nodeSelector.testKey' | tr -d '"')
+if [ "$NODE_SELECTOR" != "testValue" ]; then
+  echo $NODE_SELECTOR
+  echo "template validator deployment is missing proper nodeSelector"
+  RET=1
+fi
+
+TOLERATION=$(oc get -n ${TEST_NS} deploy virt-template-validator -ojson | jq '.spec.template.spec.tolerations[0].key' | tr -d '"')
+if [ "$TOLERATION" != "testKey" ]; then
+  echo $TOLERATION
+  echo "template validator deployment is missing proper tolerations"
+  RET=1
+fi
+
+AFFINITY=$(oc get -n ${TEST_NS} deploy virt-template-validator -ojson | jq '.spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key' | tr -d '"')
+if [ "$AFFINITY" != "testKey" ]; then
+  echo $AFFINITY
+  echo "template validator deployment is missing proper affinity"
+  RET=1
+fi
+
+oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/10-template-validator-unversioned-cr.yaml" || exit 2
+
+exit $RET

--- a/pkg/apis/kubevirt/v1/types.go
+++ b/pkg/apis/kubevirt/v1/types.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -75,6 +76,9 @@ type ComponentSpec struct {
 type TemplateValidatorSpec struct {
 	Version                   string `json:"version,omitempty"`
 	TemplateValidatorReplicas int    `json:"templateValidatorReplicas,omitempty"`
+	Affinity v1.Affinity `json:"affinity,omitempty"`
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/roles/KubevirtTemplateValidator/templates/service.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/service.yaml.j2
@@ -58,6 +58,9 @@ spec:
       labels:
         kubevirt.io: virt-template-validator
     spec:
+      affinity: {{ cr_info['spec']['affinity'] | default("", true) | from_yaml }}
+      nodeSelector: {{ cr_info['spec']['nodeSelector'] | default("", true) | from_yaml }}
+      tolerations: {{ cr_info['spec']['tolerations'] | default("", true) | from_yaml }}
       serviceAccountName: template-validator
       containers:
         - name: webhook


### PR DESCRIPTION
The placement of Template Validator pods can be controlled using the following spec fields:
```
spec.nodeSelector
spec.affinity
spec.tolerations
```

Signed-off-by: Omer Yahud <oyahud@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds the placement API as defined here: https://github.com/kubevirt/hyperconverged-cluster-operator/pull/718
to Template Validator

**Special notes for your reviewer**:
/cc @tiraboschi 
Template Validator should only accept placement parameters from `HCO_CR.spec.infra`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
It is now possible to define custom placement for KubevirtTemplateValidator using native Affinities, Node Selectors and Tolerations
```
