### PR TITLE
Add Placement API for NodeLabeller

### DIFF
--- a/deploy/crds/ssp.kubevirt.io_kubevirtnodelabellerbundles_crd.yaml
+++ b/deploy/crds/ssp.kubevirt.io_kubevirtnodelabellerbundles_crd.yaml
@@ -33,8 +33,644 @@ spec:
           spec:
             description: Spec contains the configuration of NodeLabeller
             properties:
+              affinity:
+                description: Define the node affinity for NodeLabeller pods
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: Define node selector labels for NodeLabeller pods
+                type: object
+              tolerations:
+                description: Define tolerations for NodeLabeller pods
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
               version:
-                description: Defines the version of the operand
+                description: Defines the version of the NodeLabeller
                 type: string
             type: object
           status:

--- a/deploy/crds/ssp.kubevirt.io_kubevirttemplatevalidators_crd.yaml
+++ b/deploy/crds/ssp.kubevirt.io_kubevirttemplatevalidators_crd.yaml
@@ -633,7 +633,7 @@ spec:
                 description: Defines the desired number of replicas for TemplateValidator
                 type: integer
               tolerations:
-                description: Define tolreations for TemplateValidator
+                description: Define tolerations for TemplateValidator
                 items:
                   description: The pod this Toleration is attached to tolerates any
                     taint that matches the triple <key,value,effect> using the matching

--- a/functests/11-test-node-labeller-placement.sh
+++ b/functests/11-test-node-labeller-placement.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+SCRIPTPATH=$( dirname $(readlink -f $0) )
+RES_DIR=${SCRIPTPATH}/$(basename -s .sh $0)
+source ${SCRIPTPATH}/testlib.sh
+
+RET=0
+TEST_NS="${KV_NAMESPACE}"
+
+# Test if existing affinities/nodeSelectors/tolerations are propagated to the daemon set
+echo "[test_id:4853]: Check if Node Labeller Daemon set is created"
+oc apply -n ${TEST_NS} -f "${RES_DIR}/11-node-labeller-affinity-nodeSelector-tolerations.yaml" || exit 2
+
+# Wait for the operator to create the daemon set, we don't care if pods are actually ready, as
+# we only check for the pod scheduling fields
+DAEMONSET_FOUND=false
+for i in {1..20}; do
+  oc get -n ${TEST_NS} ds kubevirt-node-labeller
+  EXIT_CODE=$?
+  if (( $EXIT_CODE == 0 )); then
+    DAEMONSET_FOUND=true
+    break
+  else
+    sleep 10
+  fi
+done
+
+if [ "$DAEMONSET_FOUND" == "false" ]; then
+  echo "kubevirt-node-labeller daemon set was not found"
+  exit 1
+fi
+
+echo "[test_id:4854]: Check if Node selector value is set as expected"
+oc get -n ${TEST_NS} ds kubevirt-node-labeller -ojson | jq '.spec.template.spec'
+NODE_SELECTOR=$(oc get -n ${TEST_NS} ds kubevirt-node-labeller -ojson | jq '.spec.template.spec.nodeSelector.testKey' | tr -d '"')
+if [ "$NODE_SELECTOR" != "testValue" ]; then
+  echo $NODE_SELECTOR
+  echo "node labeller daemon set is missing proper nodeSelector"
+  RET=1
+fi
+
+echo "[test_id:4856]: Check if Tolerations is set as expectedd"
+TOLERATION=$(oc get -n ${TEST_NS} ds kubevirt-node-labeller -ojson | jq '.spec.template.spec.tolerations[0].key' | tr -d '"')
+if [ "$TOLERATION" != "testKey" ]; then
+  echo $TOLERATION
+  echo "node labeller daemon set is missing proper tolerations"
+  RET=1
+fi
+
+echo "[test_id:4857]: Check if Affinity is set as expected"
+AFFINITY=$(oc get -n ${TEST_NS} ds kubevirt-node-labeller -ojson | jq '.spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key' | tr -d '"')
+if [ "$AFFINITY" != "testKey" ]; then
+  echo $AFFINITY
+  echo "node labeller daemon set is missing proper affinity"
+  RET=1
+fi
+
+oc delete -n ${TEST_NS} -f "${RES_DIR}/11-node-labeller-affinity-nodeSelector-tolerations.yaml" || exit 2
+
+# Wait for the daemon set from the previous test to be deleted
+DAEMONSET_DELETED=false
+for i in {1..20}; do
+  oc get -n ${TEST_NS} ds kubevirt-node-labeller
+  EXIT_CODE=$?
+  if (( $EXIT_CODE == 1 )); then
+    DAEMONSET_DELETED=true
+    break
+  else
+    sleep 10
+  fi
+done
+
+if [ "$DAEMONSET_DELETED" == "false" ]; then
+  echo "kubevirt-node-labeller daemon set was not deleted after the previous test"
+  exit 1
+fi
+
+# Test if empty affinity/nodeSelector/tolerations values are propagated to the daemon set
+oc create -n ${TEST_NS} -f "${RES_DIR}/11-node-labeller-empty-affinity-nodeSelector-tolerations.yaml" || exit 2
+
+DAEMONSET_FOUND=false
+for i in {1..20}; do
+  oc get -n ${TEST_NS} ds kubevirt-node-labeller
+  EXIT_CODE=$?
+  if (( $EXIT_CODE == 0 )); then
+    DAEMONSET_FOUND=true
+    break
+  else
+    sleep 10
+  fi
+done
+
+if [ "$DAEMONSET_FOUND" == "false" ]; then
+  echo "kubevirt-node-labeller daemon set was not found"
+  exit 1
+fi
+
+oc get -n ${TEST_NS} ds kubevirt-node-labeller -ojson | jq '.spec.template.spec'
+
+NODE_SELECTOR=$(oc get -n ${TEST_NS} ds kubevirt-node-labeller -ojson | jq '.spec.template.spec.nodeSelector' | tr -d '"')
+if [ "$NODE_SELECTOR" != "null" ] && [ "$NODE_SELECTOR" != "{}" ]; then
+  echo $NODE_SELECTOR
+  echo "node labeller daemon set is missing proper nodeSelector"
+  RET=1
+fi
+
+TOLERATION=$(oc get -n ${TEST_NS} ds kubevirt-node-labeller -ojson | jq '.spec.template.spec.tolerations' | tr -d '"')
+if [ "$TOLERATION" != "null" ] && [ "$TOLERATIONS" != "[]" ]; then
+  echo $TOLERATION
+  echo "node labeller daemon set is missing proper tolerations"
+  RET=1
+fi
+
+AFFINITY=$(oc get -n ${TEST_NS} ds kubevirt-node-labeller -ojson | jq '.spec.template.spec.affinity' | tr -d '"')
+if [ "$AFFINITY" != "null" ] && [ "$AFFINITY" != "{}" ] ; then
+  echo $AFFINITY
+  echo "node labeller daemon set is missing proper affinity"
+  RET=1
+fi
+
+oc delete -n ${TEST_NS} -f "${RES_DIR}/11-node-labeller-empty-affinity-nodeSelector-tolerations.yaml" || exit 2
+
+exit $RET

--- a/functests/11-test-node-labeller-placement/11-node-labeller-affinity-nodeSelector-tolerations.yaml
+++ b/functests/11-test-node-labeller-placement/11-node-labeller-affinity-nodeSelector-tolerations.yaml
@@ -1,0 +1,21 @@
+apiVersion: ssp.kubevirt.io/v1
+kind: KubevirtNodeLabellerBundle
+metadata:
+  name: kubevirt-node-labeller-bundle
+spec:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - preference:
+            matchExpressions:
+              - key: testKey
+                operator: In
+                values:
+                  - testValue
+          weight: 1
+  nodeSelector:
+    testKey: testValue
+  tolerations:
+  - effect: NoSchedule
+    key: testKey
+    operator: Exists

--- a/functests/11-test-node-labeller-placement/11-node-labeller-empty-affinity-nodeSelector-tolerations.yaml
+++ b/functests/11-test-node-labeller-placement/11-node-labeller-empty-affinity-nodeSelector-tolerations.yaml
@@ -1,0 +1,8 @@
+apiVersion: ssp.kubevirt.io/v1
+kind: KubevirtNodeLabellerBundle
+metadata:
+  name: kubevirt-node-labeller-bundle
+spec:
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []

--- a/pkg/apis/kubevirt/v1/types.go
+++ b/pkg/apis/kubevirt/v1/types.go
@@ -116,10 +116,19 @@ type VersionSpec struct {
 	Version string `json:"version,omitempty"`
 }
 
-// Defines the configuration of the operand
+// Defines the configuration of the NodeLabeller
 type ComponentSpec struct {
-	// Defines the version of the operand
+	// Defines the version of the NodeLabeller
 	Version string `json:"version,omitempty"`
+
+	// Define the node affinity for NodeLabeller pods
+	Affinity v1.Affinity `json:"affinity,omitempty"`
+
+	// Define node selector labels for NodeLabeller pods
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// Define tolerations for NodeLabeller pods
+	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 }
 
 // Defines the configuration of Template Validator
@@ -136,7 +145,7 @@ type TemplateValidatorSpec struct {
 	// Define node selector labels for TemplateValidator
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
-	// Define tolreations for TemplateValidator
+	// Define tolerations for TemplateValidator
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 }
 

--- a/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
+++ b/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
@@ -15,6 +15,9 @@ spec:
       labels:
         app: kubevirt-node-labeller
     spec:
+      affinity: {{ cr_info.spec.affinity | default({}, true) | to_json }}
+      nodeSelector: {{ cr_info.spec.nodeSelector | default({}, true) | to_json }}
+      tolerations: {{ cr_info.spec.tolerations | default([], true) | to_json }}
       serviceAccount: kubevirt-node-labeller
       containers:
       - name: kubevirt-node-labeller-sleeper


### PR DESCRIPTION
Signed-off-by: Shweta Padubidri <spadubid@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds the placement API as defined here: kubevirt/hyperconverged-cluster-operator#718
to Node Labeller. 
Node Labeller pods are considered workload pods. The placement of the pods can be controlled by
spec.nodeSelector
spec.affinity
spec.tolerations

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @tiraboschi
Template Validator should only accept placement parameters from HCO_CR.spec.workloads

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
