### PR TITLE
Fixed an issue with TV placement API

### DIFF
--- a/roles/KubevirtTemplateValidator/templates/service.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/service.yaml.j2
@@ -58,9 +58,9 @@ spec:
       labels:
         kubevirt.io: virt-template-validator
     spec:
-      affinity: {{ cr_info['spec']['affinity'] | default("", true) | from_yaml }}
-      nodeSelector: {{ cr_info['spec']['nodeSelector'] | default("", true) | from_yaml }}
-      tolerations: {{ cr_info['spec']['tolerations'] | default("", true) | from_yaml }}
+      affinity: {{ cr_info.spec.affinity | default("", true) | to_json }}
+      nodeSelector: {{ cr_info.spec.nodeSelector | default("", true) | to_json }}
+      tolerations: {{ cr_info.spec.tolerations | default("", true) | to_json }}
       serviceAccountName: template-validator
       containers:
         - name: webhook


### PR DESCRIPTION
Signed-off-by: Omer Yahud <oyahud@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In the DS container, variable expansion adds unicode character prefixes which cause the cluster to reject the deployment manifest. In order to circumvent that, I format the placement api fields to json format to lose the unicode prefixes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
