### PR TITLE
add missing version field in olm-catalog

### DIFF
--- a/build/update-csv.py
+++ b/build/update-csv.py
@@ -58,6 +58,7 @@ _CRD_INFOS = {
                 'The version of the KubeVirt Template Validator to deploy',
             'displayName': 'Version',
             'path': 'version',
+            'version': 'v1',
             'x-descriptors': [
                 'urn:alm:descriptor:io.kubernetes.ssp:version',
             ],
@@ -72,6 +73,7 @@ _CRD_INFOS = {
                 'The version of the KubeVirt Templates to deploy',
             'displayName': 'Version',
             'path': 'version',
+            'version': 'v1',
             'x-descriptors': [
                 'urn:alm:descriptor:io.kubernetes.ssp:version',
             ],
@@ -86,6 +88,7 @@ _CRD_INFOS = {
                 'The version of the node labeller to deploy',
             'displayName': 'Version',
             'path': 'version',
+            'version': 'v1',
             'x-descriptors': [
                 'urn:alm:descriptor:io.kubernetes.ssp:version',
             ],
@@ -100,6 +103,7 @@ _CRD_INFOS = {
                 'The version of the aggregation rules to deploy',
             'displayName': 'Version',
             'path': 'version',
+            'version': 'v1',
             'x-descriptors': [
                 'urn:alm:descriptor:io.kubernetes.ssp:version',
             ],

--- a/deploy/olm-catalog/kubevirt-ssp-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-ssp-operator.clusterserviceversion.yaml
@@ -21,6 +21,7 @@ spec:
       - description: The version of the KubeVirt Templates to deploy
         displayName: Version
         path: version
+        version: v1
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.ssp:version
       version: ''
@@ -32,6 +33,7 @@ spec:
       - description: The version of the aggregation rules to deploy
         displayName: Version
         path: version
+        version: v1
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.ssp:version
       version: ''
@@ -43,6 +45,7 @@ spec:
       - description: The version of the node labeller to deploy
         displayName: Version
         path: version
+        version: v1
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.ssp:version
       version: ''
@@ -55,6 +58,7 @@ spec:
       - description: The version of the KubeVirt Template Validator to deploy
         displayName: Version
         path: version
+        version: v1
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.ssp:version
       version: ''


### PR DESCRIPTION
**What this PR does / why we need it**:
the .spec.customresourcedefinitions.owned[].version was missing in olm-catalog. This caused
that CVP tests were failing.

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1878042

**Release note**:
```NONE

```
Signed-off-by: Karel Simon <ksimon@redhat.com>