### PR TITLE
fix generation of crds

### DIFF
--- a/hack/generate-crds.sh
+++ b/hack/generate-crds.sh
@@ -10,5 +10,7 @@ crd_files=$(ls deploy/crds/*crd.yaml)
 
 for crd in $crd_files
 do
-  echo "  preserveUnknownFields: false" >> $crd
+  if [ $(grep "preserveUnknownFields" $crd | wc -l) -eq 0 ]; then
+    echo "  preserveUnknownFields: false" >> $crd
+  fi
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes behaviour when command make generate adds in every iteration new
preserveUnknownFields field. When crd contains preserveUnknownFields,
it will not add a new one.

Signed-off-by: Karel Simon <ksimon@redhat.com>

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubevirt/kubevirt-ssp-operator/issues/248

**Release note**:
```
NONE
```
