### PR TITLE
Report available condition regardless of which template versions were deployed

### DIFF
--- a/functests/02-test-deploy-templates-openshift.sh
+++ b/functests/02-test-deploy-templates-openshift.sh
@@ -7,18 +7,9 @@ RET=1
 TEST_NS="openshift"  # TODO: check this exists?
 
 oc create -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 2
-# TODO: SSP-operator needs to improve its feedback mechanism
-sleep 21s
-for idx in $( seq 1 40); do
-	NUM=$(oc get templates -n ${TEST_NS} -l "template.kubevirt.io/type=base" -o json | jq ".items | length")
-	(( ${V} >= 1 )) && echo "templates found in ${TEST_NS}: ${NUM}"
-	if (( "${NUM}" > 0 )); then
-		(( ${V} >= 1 )) && echo "enough templates found in ${TEST_NS}"
-		RET=0
-		break
-	fi
-	sleep 3s
-done
+
+oc wait -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" -n ${TEST_NS} --for=condition=Available --timeout=600s
+
 oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 2
 
 exit $RET

--- a/functests/03-test-deploy-templates-different-namespace.sh
+++ b/functests/03-test-deploy-templates-different-namespace.sh
@@ -8,18 +8,9 @@ TEST_NS=$(uuidgen)
 
 oc create ns ${TEST_NS} || exit 2
 oc create -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 2
-# TODO: SSP-operator needs to improve its feedback mechanism
-sleep 21s
-for idx in $( seq 1 40); do
-	NUM=$(oc get templates -n ${TEST_NS} -l "template.kubevirt.io/type=base" -o json | jq ".items | length")
-	(( ${V} >= 1 )) && echo "templates found in ${TEST_NS}: ${NUM}"
-	if (( "${NUM}" > 0 )); then
-		(( ${V} >= 1 )) && echo "enough templates found in ${TEST_NS}"
-		RET=0
-		break
-	fi
-	sleep 3s
-done
+
+oc wait -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" -n ${TEST_NS} --for=condition=Available --timeout=600s
+
 oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 2
 oc delete ns ${TEST_NS} || exit 2
 

--- a/functests/04-test-deploy-templates-operator-namespace.sh
+++ b/functests/04-test-deploy-templates-operator-namespace.sh
@@ -9,18 +9,9 @@ RET=1
 TEST_NS="${SSP_OP_POD_NAMESPACE}"
 
 oc create -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 2
-# TODO: SSP-operator needs to improve its feedback mechanism
-sleep 21s
-for idx in $( seq 1 40); do
-	NUM=$(oc get templates -n ${TEST_NS} -l "template.kubevirt.io/type=base" -o json | jq ".items | length")
-	(( ${V} >= 1 )) && echo "templates found in ${TEST_NS}: ${NUM}"
-	if (( "${NUM}" > 0 )); then
-		(( ${V} >= 1 )) && echo "enough templates found in ${TEST_NS}"
-		RET=0
-		break
-	fi
-	sleep 3s
-done
+
+oc wait -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" -n ${TEST_NS} --for=condition=Available --timeout=600s
+
 oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 2
 
 exit $RET

--- a/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
+++ b/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
@@ -55,12 +55,12 @@
 # If the old cr exists, it would have a metadata field
 - name: Check if the old CR exists
   set_fact:
-    old_cr_exists: "{{ true if (old_cr is defined) and (old_cr.metadata | default(None)) != None else false }}"
+    old_cr_exists: "{{ True if (old_cr is defined) and (old_cr.metadata | default(None)) != None else False }}"
 
 - name: Filter for templates owned by the old cr
   set_fact:
     old_cr_templates: "{{ templates | k8s_owned_by(old_cr) }}"
-  when: "{{ old_cr_exists==true }}"
+  when: old_cr_exists == True
 
 # Inject ownerReferences
 - name: Inject owner references for KubevirtCommonTemplatesBundle
@@ -69,23 +69,19 @@
     namespace: "{{ cr_info.metadata.namespace }}"
     merge_type: ['merge', 'json']
     resource_definition: "{{ old_cr_templates | k8s_inject_ownership(cr_info) }}"
-  when: "{{ (old_cr_templates is defined) and (old_cr_templates | length > 0) }}"
+  when: (old_cr_templates is defined) and (old_cr_templates | length > 0)
 
 - name: "Count all new templates in file"
   set_fact:
     new_templates: "{{ lookup('file', 'common-templates-'+ version +'.yaml').split('\n---\n') | select('search', '(^|\n)[^#]') | list | length }}"
 
-- name: "Set label"
-  set_fact:
-    label: "template.kubevirt.io/version={{ version }}"
-
 - name: "Get all templates"
   set_fact:
-    deployed_templates_after: "{{ lookup('k8s', api_version=ct_status.result.results[0].result.apiVersion, kind='template', label_selector=label) | length }}"
+    deployed_templates_after: "{{ lookup('k8s', api_version=ct_status.result.results[0].result.apiVersion, kind='template', label_selector='template.kubevirt.io/type=base') | length }}"
 
 - name: "Set Available status"
   set_fact:
-    available: "{{ true if new_templates <= deployed_templates_after else false }}"
+    available: "{{ True if new_templates <= deployed_templates_after else False }}"
 
 - name: Set progressing condition
   operator_sdk.util.k8s_status:
@@ -132,4 +128,4 @@
     namespace: "{{ cr_info.metadata.namespace }}"
     status:
       observedVersion: "{{ operator_version }}"
-  when: available == true
+  when: available == True


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, all templates were aligned to the same version, but a previous fix (https://github.com/kubevirt/kubevirt-ssp-operator/pull/253)

locked deprecated templates to older versions, so the operator did not report the Available condition.

This fix makes the operator report Available when all templates were deployed, regardless of their version.

Signed-off-by: Omer Yahud <oyahud@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Which issue(s) this PR fixes** 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1904830

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
